### PR TITLE
add default value constraint for uuid primary key according to Sequel

### DIFF
--- a/lib/event_sourcery/postgres/schema.rb
+++ b/lib/event_sourcery/postgres/schema.rb
@@ -53,7 +53,7 @@ module EventSourcery
       def create_aggregates(db: EventSourcery::Postgres.config.event_store_database,
                             table_name: EventSourcery::Postgres.config.aggregates_table_name)
         db.create_table(table_name) do
-          primary_key :aggregate_id, :uuid, default: Sequel.lit('uuid_generate_v4()')
+          uuid :aggregate_id, primary_key: true
           column :version, :bigint, default: 1
         end
       end


### PR DESCRIPTION
On Postgres 11 the following error is generated when trying to create
the aggregates table unless a default constraint is added.

```
Sequel::DatabaseError:
  PG::InvalidParameterValue: ERROR:  identity column type must be smallint, integer, or bigint
```